### PR TITLE
API fixes for Deployment, deployer controllers, and Deployer#AddPod

### DIFF
--- a/pkg/api/deployer_controller.go
+++ b/pkg/api/deployer_controller.go
@@ -21,7 +21,19 @@ under the License.
 
 package api
 
+import (
+	"k8s.io/client-go/kubernetes"
+
+	extensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+)
+
+// ControllerResources defines the resources the deployer will provide controllers
+type ControllerResources struct {
+	kubeClient           *kubernetes.Clientset
+	kubeExtensionsClient *extensionsclient.Clientset
+}
+
 // DeployerControllerInterface defines the interface for controllers
 type DeployerControllerInterface interface {
-	Run(chan struct{}) error
+	Run(ControllerResources, chan struct{}) error
 }

--- a/pkg/api/deployment.go
+++ b/pkg/api/deployment.go
@@ -27,7 +27,7 @@ type DeploymentConfig struct {
 	ClusterName             string
 	Name                    string
 	Namespace               string
-	Replicas                int32
+	Replicas                *int32
 	Recreate                bool
 	MaxUnavailable          string
 	MaxExtra                string

--- a/pkg/components/deployment.go
+++ b/pkg/components/deployment.go
@@ -43,7 +43,7 @@ func NewDeployment(config api.DeploymentConfig) *Deployment {
 		Cluster:                 config.ClusterName,
 		Name:                    config.Name,
 		Namespace:               config.Namespace,
-		Replicas:                &config.Replicas,
+		Replicas:                config.Replicas,
 		Recreate:                config.Recreate,
 		MinReadySeconds:         config.MinReadySeconds,
 		RevisionHistoryLimit:    config.RevisionHistoryLimit,

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -159,6 +159,11 @@ func (d *Deployer) AddServiceAccount(obj *components.ServiceAccount) {
 	d.serviceAccounts[obj.GetName()] = obj.GetObj()
 }
 
+// AddPod will add the provided pod to the pods that will be deployed
+func (d *Deployer) AddPod(obj *components.Pod) {
+	d.pods[obj.GetName()] = obj.GetObj()
+}
+
 // Run starts the deployer and deploys all components to the cluster
 func (d *Deployer) Run() error {
 	allErrs := map[util.ComponentType][]error{}
@@ -224,10 +229,14 @@ func (d *Deployer) StartControllers(stopCh chan struct{}) map[string][]error {
 
 	// Run the controllers if there are any configured
 	if len(d.controllers) > 0 {
+		resources := api.ControllerResources{
+			kubeClient:           d.client,
+			kubeExtensionsClient: d.apiextensions,
+		}
 		errCh := make(chan map[string]error)
 		for n, c := range d.controllers {
 			go func(name string, controller api.DeployerControllerInterface) {
-				err := controller.Run(stopCh)
+				err := controller.Run(resources, stopCh)
 				if err != nil {
 					errCh <- map[string]error{name: err}
 				}


### PR DESCRIPTION
Fixed Deployment replicas to be a pointer, added AddPod to the deployer, and added ControllerResources to the Run interface for deployer controllers