### PR TITLE
Ensure that we set .spec.selector in order to support kubernetes 1.8+

### DIFF
--- a/pkg/components/stateful_set.go
+++ b/pkg/components/stateful_set.go
@@ -105,7 +105,7 @@ func (s *StatefulSet) AddPod(obj *Pod) error {
 	o := obj.GetObj()
 	s.obj.TemplateMetadata = &o.PodTemplateMeta
 	s.obj.PodTemplate = o.PodTemplate
-
+	s.AddMatchLabelsSelectors(o.PodTemplateMeta.Labels)
 	return nil
 }
 


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector

> You must set the .spec.selector field of a StatefulSet to match the labels of its .spec.template.metadata.labels. Prior to Kubernetes 1.8, the .spec.selector field was defaulted when omitted. In 1.8 and later versions, failing to specify a matching Pod Selector will result in a validation error during StatefulSet creation.